### PR TITLE
Added path param size check on get requests

### DIFF
--- a/source/microsvc_controller.cpp
+++ b/source/microsvc_controller.cpp
@@ -41,16 +41,14 @@ void MicroserviceController::initRestOpHandlers() {
 void MicroserviceController::handleGet(http_request message) {
     auto path = requestPath(message);
     if (!path.empty()) {
-        if (path[0] == "service" && path[1] == "test") {
+        if (path.size() == 2 && path[0] == "service" && path[1] == "test") {
             auto response = json::value::object();
             response["version"] = json::value::string("0.1.1");
             response["status"] = json::value::string("ready!");
             message.reply(status_codes::OK, response);
         }
     }
-    else {
-        message.reply(status_codes::NotFound);
-    }
+    message.reply(status_codes::NotFound);
 }
 
 void MicroserviceController::handlePatch(http_request message) {


### PR DESCRIPTION
Added path param size check so that it doesn't cause runtime error on path size of size 1. eg. `http://<HOST>:6502/v1/ivmero/api/service`