### PR TITLE
Fixed Build failure - Issue #20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ if(UNIX) # Darwing or Linux
 	    list(REVERSE OPENSSL_ROOT_DIR)
 
         find_package(OpenSSL 1.0.2 REQUIRED)
-        set(OPENSSL_VERSION "1.0.2p")
+        set(OPENSSL_VERSION "1.0.2s")
     else()
         find_package(OpenSSL 1.0.1 REQUIRED)
         set(OPENSSL_VERSION "1.0.1")

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This is a sample that shows how to implement a micro-serivce on C++ using the C+
           $ brew install cmake git openssl boost zlib
           
 2. Clone the repository.
+3. Execute the below command:
+          $ export OPENSSL_ROOT_DIR=/usr/local/opt/openssl
 3. Go to the directory micro-service/libs and execute the script: ```./build_dependencies.sh``` that'll clone the [C++ REST SDK](https://github.com/Microsoft/cpprestsdk) repository and will build the static version of the library, if you want to build the dynamic link version of the library just on the **build_dependencies.sh** script remove the flag: ```-DBUILD_SHARED_LIBS=OFF```.
 4. Go to the directory micro-service and type the following commands:
 

--- a/README.md
+++ b/README.md
@@ -10,25 +10,27 @@ This is a sample that shows how to implement a micro-serivce on C++ using the C+
           $ brew install cmake git openssl boost zlib
           
 2. Clone the repository.
-3. Execute the below command:
+3. Execute the below command: 
+
           $ export OPENSSL_ROOT_DIR=/usr/local/opt/openssl
-3. Go to the directory micro-service/libs and execute the script: ```./build_dependencies.sh``` that'll clone the [C++ REST SDK](https://github.com/Microsoft/cpprestsdk) repository and will build the static version of the library, if you want to build the dynamic link version of the library just on the **build_dependencies.sh** script remove the flag: ```-DBUILD_SHARED_LIBS=OFF```.
-4. Go to the directory micro-service and type the following commands:
+          
+4. Go to the directory micro-service/libs and execute the script: ```./build_dependencies.sh``` that'll clone the [C++ REST SDK](https://github.com/Microsoft/cpprestsdk) repository and will build the static version of the library, if you want to build the dynamic link version of the library just on the **build_dependencies.sh** script remove the flag: ```-DBUILD_SHARED_LIBS=OFF```.
+5. Go to the directory micro-service and type the following commands:
 
           $ mkdir build
           $ cd build
           $ cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug ..
           
-5. Finally type the command:
+6. Finally type the command:
 
           $ make -j 8
           
-6. On ```./build``` directory type and you should see the following output:
+7. On ```./build``` directory type and you should see the following output:
 
           $ ./micro-service   
           $ Modern C++ Microservice now listening for requests at: http://<your computer's IP>:6502/v1/ivmero/api
              
-7. To perform a benchmark on the Modern C++ Microservice I had included two **lua** scritps which can be executed using [WRK2](https://github.com/giltene/wrk2) HTTP Benckmark Tool, using the following command:
+8. To perform a benchmark on the Modern C++ Microservice I had included two **lua** scritps which can be executed using [WRK2](https://github.com/giltene/wrk2) HTTP Benckmark Tool, using the following command:
 
           $ ./wrk -c100 -t8 -d60s -s benchmark_microsvc.lua http://192.168.100.6:6502 --latency --rate 2000
           

--- a/libs/build_dependencies.sh
+++ b/libs/build_dependencies.sh
@@ -2,6 +2,7 @@
 
 RESTSDK_VERSION="v2.10.6"
 DEFAULT_LIB_DIRECTORY_PATH="."
+OPENSSL_ROOT_DIR="/usr/local/opt/openssl"
 
 libDir=${1:-$DEFAULT_LIB_DIRECTORY_PATH}
 
@@ -14,7 +15,7 @@ install_cpprestsdk(){
    fi
    
 	git clone https://github.com/Microsoft/cpprestsdk.git "$restsdkDir"
-	(cd $restsdkDir && git checkout tags/$RESTSDK_VERSION -b $RESTSDK_VERSION)
+	(cd $restsdkDir && git submodule update --init && git checkout tags/$RESTSDK_VERSION -b $RESTSDK_VERSION)
 	mkdir "$restsdkBuildDir"
 	if [[ "$OSTYPE" == "linux-gnu" ]]; then
 		export CXX=g++-4.9


### PR DESCRIPTION
- Fixed CMake Error in finding OpenSSL on MAC: Execute the below command
`export OPENSSL_ROOT_DIR=/usr/local/opt/openssl`
And changing the required version in the ´CMakeList.txt´ (line 18) from ´1.0.2p´ to ´1.0.2s´.
- Fixed problems concerning to Boost: This issue is due to older websocketpp being incompatible with the latest version of boost. Instead of uninstalling and trying to install older version of boost library (boost 1.60 is dibbled on Homebrew), one can update the websocketpp library in cpprestsdk by making the following change the line #18 in "build_dependencies.sh" as below
`(cd $restsdkDir && git submodule update --init && git checkout tags/$RESTSDK_VERSION -b $RESTSDK_VERSION)`